### PR TITLE
Исправлен баг с изменением верстки для неавторизированных пользователей

### DIFF
--- a/src/features/comments/CommentsList.jsx
+++ b/src/features/comments/CommentsList.jsx
@@ -18,6 +18,7 @@ const StyledProfile = styled.div`
 
 const StyledCommentText = styled.div`
   .toastui-editor-contents {
+    margin-top: 10px;
     font-size: 16px;
   }
 `;


### PR DESCRIPTION
Баг возникал из-за того что для не авторизованных пользователей не рендерится редактор для комментариев, в свяи с чем, почему-то пропадал margin (10px) между аваторкой пользователя кто оставил комментарий и самим комметарием

Проблему удалось решить явным указанием margin: 10px в styled компоненте