### PR TITLE
Исправил проблему с повторной загрузкой списка вопросов #297

### DIFF
--- a/src/features/questions/questions-list/QuestionsList.jsx
+++ b/src/features/questions/questions-list/QuestionsList.jsx
@@ -38,6 +38,7 @@ const QuestionsList = () => {
   const isCompactMode = useSelector(selectIsCompactModeToogle);
 
   const questionsIds = useSelector(questionSelectors.selectIds);
+  const questionsAll = useSelector(questionSelectors.selectAll);
 
   const scrollHandler = useCallback(
     (e) => {
@@ -67,8 +68,10 @@ const QuestionsList = () => {
   }, [deletedOnly, dispatch, favoritesOnly]);
 
   useEffect(() => {
-    dispatch(fetchQuestions({ favoritesOnly, deletedOnly }));
-  }, [deletedOnly, dispatch, favoritesOnly]);
+    if (!questionsAll.length) {
+      dispatch(fetchQuestions({ favoritesOnly, deletedOnly }));
+    }
+  }, [deletedOnly, dispatch, favoritesOnly, questionsAll.length]);
 
   const QuestionWrapper = isCompactMode ? Paper : React.Fragment;
   const generatedTitle = generateTitle(deletedOnly, favoritesOnly);

--- a/src/features/questions/questionsSlice.js
+++ b/src/features/questions/questionsSlice.js
@@ -179,7 +179,7 @@ const questionsSlice = createSlice({
     },
 
     [resetQuestionsList]: (state) => {
-      questionsAdapter.removeAll(state);
+      // questionsAdapter.removeAll(state);
 
       state.pagination.offset = 0;
       state.pagination.totalQuestions = 0;


### PR DESCRIPTION
Проблема заключалась в том что, в каждый раз вызывался метод removeAll, пока только закомментировал строчку, потому что не совсем понятно для чего его вызывать и добавил в useEffect проверку. Теперь при переходе с вопроса на список вопросов повторной загрузки не происходит. 
