### PR TITLE
Изменил в файле AdaptiveMenu значение ключа contrast на строку

### DIFF
--- a/src/components/layout/header/AdaptiveMenu.jsx
+++ b/src/components/layout/header/AdaptiveMenu.jsx
@@ -43,7 +43,7 @@ const AdaptiveMenu = ({ toggleMobileMenu, mobileMenu }) => {
         jsx: (
           <Button
             className="d-block mb-2"
-            contrast={false}
+            contrast={`${false}`}
             color="primary"
             onClick={handleAddQuestion}
           >
@@ -80,7 +80,7 @@ const AdaptiveMenu = ({ toggleMobileMenu, mobileMenu }) => {
         jsx: (
           <Button
             className="d-block m-auto"
-            contrast={false}
+            contrast={`${false}`}
             color="primary"
             onClick={executeLoggingInProcess}
           >


### PR DESCRIPTION
Эта ошибка, styled-componentsпо-видимому, связана с styled()попыткой применить логическое значение к элементу в DOM, но элементы DOM принимают только строки в качестве атрибутов.